### PR TITLE
add saving of access token resolves #4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,7 +72,8 @@
                                   [peridot "0.4.3"]
                                   [com.cemerick/piggieback "0.2.1"]
                                   [duct/figwheel-component "0.3.1"]
-                                  [figwheel "0.5.0-1"]]
+                                  [figwheel "0.5.0-1"]
+                                  [org.clojars.runa/conjure "2.1.3"]]
                    :source-paths ["dev"]
                    :repl-options {:init-ns user
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}

--- a/src/dertwothumber/component/repo.clj
+++ b/src/dertwothumber/component/repo.clj
@@ -3,6 +3,11 @@
             [com.stuartsierra.component :as component]
             [tentacles.repos]))
 
+(defn encrypt-access-token
+       "This is a noop for now but needs to be fixed for production use"
+       [access-token]
+  access-token)
+
 (defprotocol DbFunctions
   (create-repo [this attributes] "Create a repo in the database")
   (get-repo [this full-name] "get repo by full-name"))
@@ -35,9 +40,13 @@
       (tentacles.repos/create-hook user-id repo-name "web"
                                    {:url (:webhooks-url github-config)}
                                    {:active true
-                                    :events [:pull_request_review_comment :push
+                                    :events [:pull_request_review_comment
+                                             :push
                                              :pull_request]
-                                    :oauth-token access-token}))))
+                                    :oauth-token access-token})
+      (create-repo this {:full-name (str user-id "/" repo-name)
+                         :access-token (encrypt-access-token access-token)
+                         :active true}))))
 
 (defn create-table [dynamo-db]
   (dynamo-db/create-table dynamo-db :repos [:full-name :s]))

--- a/test/dertwothumber/component/repo_test.clj
+++ b/test/dertwothumber/component/repo_test.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer :all]
             [com.stuartsierra.component :as component]
             [dertwothumber.component.dynamo-db :as dynamo-db]
-            [dertwothumber.component.repo :as repo]))
+            [dertwothumber.component.repo :as repo]
+            [conjure.core :refer [mocking verify-call-times-for verify-first-call-args-for]]
+            [tentacles.repos]))
 
 (defn new-repo-system []
   (let [test-config {:access-key "<AWS_DYNAMODB_ACCESS_KEY>"
@@ -28,4 +30,13 @@
     (testing "creating a repo"
       (repo/create-repo repo {:full-name "tobowers/test-repo" :url "http://something"}))
     (testing "fetching a repo"
-      (is (= "http://something" (:url (repo/get-repo repo "tobowers/test-repo")))))))
+      (is (= "http://something" (:url (repo/get-repo repo "tobowers/test-repo")))))
+    (testing "creating repo hook"
+      (mocking [tentacles.repos/create-hook]
+        (repo/create-hook repo "user-id" "repo-name" "access-token")
+        (verify-call-times-for tentacles.repos/create-hook 1)
+        (verify-first-call-args-for tentacles.repos/create-hook "user-id" "repo-name" "web"
+                                                                {:url "http://localhost/webhooks"}
+                                                                {:active true
+                                                                 :events [:pull_request_review_comment :push :pull_request]
+                                                                 :oauth-token "access-token"})))))

--- a/test/dertwothumber/component/repo_test.clj
+++ b/test/dertwothumber/component/repo_test.clj
@@ -39,4 +39,5 @@
                                                                 {:url "http://localhost/webhooks"}
                                                                 {:active true
                                                                  :events [:pull_request_review_comment :push :pull_request]
-                                                                 :oauth-token "access-token"})))))
+                                                                 :oauth-token "access-token"}))
+        (is (= true (:active (repo/get-repo repo "user-id/repo-name")))))))


### PR DESCRIPTION
#4. In the "simplest thing that could possibly work" vein this just saves a repo into the db with the access token once a user turns it on.

The changeset looks big because #10 is included in this PR.
