### PR TITLE
need to process the actual thumb as well

### DIFF
--- a/src/dertwothumber/pull_request.clj
+++ b/src/dertwothumber/pull_request.clj
@@ -4,7 +4,7 @@
             [clojure.string]
             [tentacles.core :refer [api-call]]))
 
-(def thumbs-up-regex #"\:\+1\:")
+(def thumbs-up-regex #"(\:\+1\:|👍)") ; character after the | is a github emoji
 
 (defprotocol GithubFunctions
   (get-comments [pull-request] "fetch the comments for a pull-request (for some reason this uses the issue API)")


### PR DESCRIPTION
github now sends thumbs as utf-8 thumbs as well.
